### PR TITLE
Prevent installing recommended packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM php:7.4-fpm
 RUN apt-get update -y
 
 #essential files
-RUN apt-get install -y \
+RUN apt-get install -y --no-install-recommends \
     build-essential \
     libpng-dev \
     libonig-dev \


### PR DESCRIPTION
Many of the used packages bring along their docs. They are not needed on an application container.